### PR TITLE
sleep_poll macro to check for exit key events during blocking sleep

### DIFF
--- a/castle_quest/src/credits.rs
+++ b/castle_quest/src/credits.rs
@@ -1,6 +1,3 @@
-use std::time::Duration;
-use std::thread;
-
 use sdl2::pixels::Color;
 use sdl2::image::LoadTexture;
 use sdl2::rect::Rect;
@@ -17,7 +14,7 @@ macro_rules! credits_page {
 		$closure();
 
 		$core.wincan.present();
-		thread::sleep(Duration::from_millis(CREDITS_TIMEOUT));
+		sleep_poll!($core, CREDITS_TIMEOUT);
 	}
 }
 
@@ -72,7 +69,7 @@ pub fn credits(core: &mut SDLCore) -> Result<(), String> {
 		let kaleb_credit = core.texture_creator.load_texture("images/KalebRCreditImage.png")?;
 		core.wincan.copy(&kaleb_credit, None, None)?;
 	});
-	
+
 	//Jared Carl Credit Image
 	credits_page!(core, {
 		core.wincan.set_draw_color(Color::RGBA(255, 255, 255, 128));
@@ -80,14 +77,14 @@ pub fn credits(core: &mut SDLCore) -> Result<(), String> {
 
 		let jared_credit = core.texture_creator.load_texture("images/JaredCCreditImage.png")?;
 		core.wincan.copy(&jared_credit, None, centered_rect!(core, _, 200, 256, 200))?;
-	
+
 		let text_surface = regular_font.render("Jared Carl")
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 320)
 			.map_err(|e| e.to_string())?;
-	
+
 		let text_texture = core.texture_creator.create_texture_from_surface(&text_surface)
 			.map_err(|e| e.to_string())?;
-	
+
 		core.wincan.copy(&text_texture, None, centered_rect!(core, _, 400, 550, 200))?;
 	});
 
@@ -135,7 +132,7 @@ pub fn credits(core: &mut SDLCore) -> Result<(), String> {
 		let bianca_credit = core.texture_creator.load_texture("images/BiancaCredit.png")?;
 		core.wincan.copy(&bianca_credit, None, None)?;
 	});
-  
+
 	//Jake Baumbaugh Credit Image
 	credits_page!(core, {
 		let jake_credit = core.texture_creator.load_texture("images/JakeBCreditImageWithText.png")?;


### PR DESCRIPTION
- Adds a `sleep_poll!(core, millis)` macro to occasionally check for key events during a blocking sleep
- Changes `thread::sleep` in the credits page to use the `sleep_poll` macro