### PR TITLE
Addition of banners & very basic turn sequence controlled by player

### DIFF
--- a/castle_quest/src/credits.rs
+++ b/castle_quest/src/credits.rs
@@ -20,6 +20,8 @@ macro_rules! credits_page {
 }
 
 pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
+	let texture_creator = core.wincan.texture_creator();
+
 	let bold_font = core.ttf_ctx.load_font("fonts/OpenSans-Bold.ttf", 32)?; //From https://www.fontsquirrel.com/fonts/open-sans
 	let regular_font = core.ttf_ctx.load_font("fonts/OpenSans-Regular.ttf", 16)?; //From https://www.fontsquirrel.com/fonts/open-sans
 
@@ -32,7 +34,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 			.blended_wrapped(Color::RGBA(0, 0, 0, 96), 100) //Black font
 			.map_err(|e| e.to_string())?;
 
-		let text_texture = core.texture_creator.create_texture_from_surface(&text_surface)
+		let text_texture = texture_creator.create_texture_from_surface(&text_surface)
 			.map_err(|e| e.to_string())?;
 
 		core.wincan.copy(&text_texture, None, centered_rect!(core, 500, 500))?;
@@ -47,7 +49,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 160) //Black font
 			.map_err(|e| e.to_string())?;
 
-		let text_texture = core.texture_creator.create_texture_from_surface(&text_surface)
+		let text_texture = texture_creator.create_texture_from_surface(&text_surface)
 			.map_err(|e| e.to_string())?;
 
 		core.wincan.copy(&text_texture, None, centered_rect!(core, 500, 250))?;
@@ -58,7 +60,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(201, 196, 196, 128));
 		core.wincan.clear();
 
-		let alex_credit = core.texture_creator.load_texture("images/AlexKCreditImageWithText.png")?;
+		let alex_credit = texture_creator.load_texture("images/AlexKCreditImageWithText.png")?;
 		core.wincan.copy(&alex_credit, None, None)?;
 	});
 
@@ -67,7 +69,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(201, 196, 196, 128));
 		core.wincan.clear();
 
-		let kaleb_credit = core.texture_creator.load_texture("images/KalebRCreditImage.png")?;
+		let kaleb_credit = texture_creator.load_texture("images/KalebRCreditImage.png")?;
 		core.wincan.copy(&kaleb_credit, None, None)?;
 	});
 
@@ -76,14 +78,14 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(255, 255, 255, 128));
 		core.wincan.clear();
 
-		let jared_credit = core.texture_creator.load_texture("images/JaredCCreditImage.png")?;
+		let jared_credit = texture_creator.load_texture("images/JaredCCreditImage.png")?;
 		core.wincan.copy(&jared_credit, None, centered_rect!(core, _, 200, 256, 200))?;
 
 		let text_surface = regular_font.render("Jared Carl")
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 320)
 			.map_err(|e| e.to_string())?;
 
-		let text_texture = core.texture_creator.create_texture_from_surface(&text_surface)
+		let text_texture = texture_creator.create_texture_from_surface(&text_surface)
 			.map_err(|e| e.to_string())?;
 
 		core.wincan.copy(&text_texture, None, centered_rect!(core, _, 400, 550, 200))?;
@@ -94,7 +96,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(201, 196, 196, 128));
 		core.wincan.clear();
 
-		let colin_credit = core.texture_creator.load_texture("images/ColinWCreditImage.png")?;
+		let colin_credit = texture_creator.load_texture("images/ColinWCreditImage.png")?;
 		core.wincan.copy(&colin_credit, None, None)?;
 	});
 
@@ -107,7 +109,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 320) //Black font
 			.map_err(|e| e.to_string())?;
 
-		let text_texture = core.texture_creator.create_texture_from_surface(&text_surface)
+		let text_texture = texture_creator.create_texture_from_surface(&text_surface)
 			.map_err(|e| e.to_string())?;
 
 		core.wincan.copy(&text_texture, None, centered_rect!(core, 1000, 250))?;
@@ -115,14 +117,14 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 
 	// James Fenn Credit Image
 	credits_page!(core, {
-		let james_credit = core.texture_creator.load_texture("images/JamesFCreditImage.png")?;
+		let james_credit = texture_creator.load_texture("images/JamesFCreditImage.png")?;
 		core.wincan.copy(&james_credit, None, centered_rect!(core, _, 200, 256, 256))?;
 
 		let text_surface = regular_font.render("James Fenn")
 			.blended_wrapped(Color::RGBA(128, 128, 128, 128), 320) //Black font
 			.map_err(|e| e.to_string())?;
 
-		let text_texture = core.texture_creator.create_texture_from_surface(&text_surface)
+		let text_texture = texture_creator.create_texture_from_surface(&text_surface)
 			.map_err(|e| e.to_string())?;
 
 		core.wincan.copy(&text_texture, None, centered_rect!(core, _, 400, 500, 125))?;
@@ -130,19 +132,19 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 
 	//Bianca Finamore Credit Image
 	credits_page!(core, {
-		let bianca_credit = core.texture_creator.load_texture("images/BiancaCredit.png")?;
+		let bianca_credit = texture_creator.load_texture("images/BiancaCredit.png")?;
 		core.wincan.copy(&bianca_credit, None, None)?;
 	});
 
 	//Jake Baumbaugh Credit Image
 	credits_page!(core, {
-		let jake_credit = core.texture_creator.load_texture("images/JakeBCreditImageWithText.png")?;
+		let jake_credit = texture_creator.load_texture("images/JakeBCreditImageWithText.png")?;
 		core.wincan.copy(&jake_credit, None, None)?;
 	});
 
 	// Shane Josapak Credit Image
 	credits_page!(core, {
-		let shane_credit = core.texture_creator.load_texture("images/ShaneJCreditImage.png")?;
+		let shane_credit = texture_creator.load_texture("images/ShaneJCreditImage.png")?;
 		core.wincan.copy(&shane_credit, None, None)?;
 	});
 

--- a/castle_quest/src/main.rs
+++ b/castle_quest/src/main.rs
@@ -29,7 +29,6 @@ pub struct SDLCore {
 	pub wincan: sdl2::render::WindowCanvas,
 	pub event_pump: sdl2::EventPump,
 	pub cam: Rect,
-	pub texture_creator: sdl2::render::TextureCreator<sdl2::video::WindowContext>
 }
 
 fn runner(vsync:bool) {
@@ -101,15 +100,12 @@ fn init_sdl_core(vsync:bool) -> Result<SDLCore, String> {
 
 	let cam = Rect::new(0, 0, CAM_W, CAM_H);
 
-	let texture_creator = wincan.texture_creator();
-
 	let core = SDLCore{
 		sdl_ctx,
 		ttf_ctx,
 		wincan,
 		event_pump,
 		cam,
-		texture_creator,
 	};
 
 	Ok(core)


### PR DESCRIPTION
- Add some initial functionality into single player
- Display banner representing current player that lasts for a few seconds before disappearing
- This cycles through player 1's turn, player 2's turn, and the barbarians turn.
- Press "backspace" in order to cycle through each one. (In the future, instead of backspace, this would be controlled by after player 1 clicks end turn, after player 2 ai returns their moves, and after the barbarians ai returns their moves in order to signal when the ai has finished making their moves)
- I just did "backspace" to cycle through all since I was not sure how we wanted to handle each move, let alone players themselves