### PR TITLE
Editing attack range

### DIFF
--- a/src/single_player.rs
+++ b/src/single_player.rs
@@ -185,6 +185,9 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 	let mut active_unit_i: i32 = -1;
 	let mut active_unit_j: i32 = -1;
 
+	// Do this right before the game starts so that player 1 starts
+	p1_units = initialize_next_turn(p1_units);
+	
 	'gameloop: loop {
 		core.wincan.clear();
 
@@ -326,7 +329,7 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 										{
 											if let Some(mut unit) = p1_units.remove(&(active_unit_j.try_into().unwrap(), active_unit_i.try_into().unwrap())) {
 												unit.update_pos(j, i);
-												unit.has_moved = false;
+												unit.has_moved = true;
 												p1_units.insert((j, i), unit);
 											}
 										}
@@ -383,6 +386,7 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 			Team::Barbarians => {
 				if !banner_visible {
 					//End turn
+					p1_units = initialize_next_turn(p1_units);
 					current_player = Team::Player;
 
 					//Start displaying Player 1's banner
@@ -475,6 +479,14 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 
 	//Single player finished running cleanly, automatically quit game
 	Ok(GameState::Quit)
+}
+
+// Function that takes a HashMap of units and sets all has_attacked and has_moved to false so that they can move again
+fn initialize_next_turn(mut team_units: HashMap<(u32, u32), Unit>) -> HashMap<(u32, u32), Unit>{
+	for unit in &mut team_units.values_mut() {
+		unit.next_turn();
+	}
+	team_units
 }
 
 fn draw_player_banner(core: &mut SDLCore, text_textures: &HashMap<&str, Texture>, text_index: &str, rect_color: Color) -> Result< (), String> {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -112,6 +112,11 @@ impl Unit <'_>{
         self.y = y;
     }
 
+    pub fn next_turn(&mut self) {
+        self.has_attacked = false;
+        self.has_moved = false;
+    }
+
     pub fn get_tiles_in_movement_range(&self, map: &mut HashMap<(u32, u32), Tile>,) -> Vec<(u32, u32)> {
         let mut tiles_in_range: Vec<(u32, u32)> = Vec::new();
         let mut visited: HashMap<(u32,u32), bool> = HashMap::new();


### PR DESCRIPTION
Don't delete branch after merging, the attack range still needs to be edited, just wanted to get some fixes and ideas into Week-4
**Range of Melee class was set to 6 for testing purposes, will be changed later!**
- Implemented a basic attack range, pretty much just slightly altering the setup done by @AlexKwi
  - Issue: Range is not realistic, follows the same algorithm as movement, so some walls can be attacked through at the right position. Would need to find a way to tell if a space is behind a mountain block or not, but my brain is not big enough to figure out the right way to do that
    - Added two more units to test where issues could potentially arise, the one near the bottom of the screen shows the attack range issue more clearly, but both have issues
- Fixed issue where the movement grid would not follow a unit when it moved
- Attempted to set up the visual aspect of a turn, where you would move first and then be able to attack
  - Issue: Does not always work, the mouse controls are acting incredibly weird for some reason. Sometimes the left click will open up the movement menu and sometimes it will flicker between the movement and attack grid. Afterwards it sets the has_moved variable to true so that only the attack range pops up, which is at least correct. I originally assumed that the issue was caused by left click being registered over multiple frames, but that doesn't seem to be the issue when I was testing the output. So pretty much I'm at a loss as to why it doesn't work properly
  - Best bet would be to just ignore the issues and hope that it'll work properly when we get the buttons on the scroll to work