### PR TITLE
refactor main_menu to fix lifetime issues & allow more abstraction

### DIFF
--- a/src/button.rs
+++ b/src/button.rs
@@ -1,0 +1,50 @@
+use sdl2::pixels::Color;
+use sdl2::rect::Rect;
+use sdl2::mouse::MouseState;
+use sdl2::render::{BlendMode, Texture, TextureCreator};
+
+use crate::SDLCore;
+
+pub struct Button<'r> {
+	rect: Rect,
+	text: String,
+	text_size: (u32, u32),
+	texture: sdl2::render::Texture<'r>,
+}
+
+impl Button<'_> {
+	pub fn new<'r>(core: &SDLCore<'r>, rect: Rect, text: &str) -> Result<Button<'r>, String> {
+		let texture = core.texture_creator.create_texture_from_surface(
+			&core.bold_font.render(text)
+				.blended_wrapped(Color::RGBA(255, 255, 255, 128), 320)
+				.map_err(|e| e.to_string())?
+		).map_err(|e| e.to_string())?;
+
+		Ok(Button {
+			rect,
+			text: text.to_string(),
+			text_size: core.bold_font.size_of(text).map_err(|e| "Could not determine text size")?,
+			texture,
+		})
+	}
+
+	pub fn is_mouse(&self, core: &SDLCore) -> bool {
+		let mouse_state: MouseState = core.event_pump.mouse_state();
+		let mouse_pos = (mouse_state.x(), mouse_state.y());
+
+		self.rect.contains_point(mouse_pos)
+	}
+
+	pub fn draw<'r>(&self, core: &mut SDLCore<'r>) -> Result<(), String> {
+		let color = if self.is_mouse(core) { Color::RGBA(100,100,100,100) } else { Color::RGBA(50,50,50,100) };
+		let (w, h) = self.text_size;
+		let x: i32 = (self.rect.width() as i32 - w as i32) / 2;
+		let y: i32 = (self.rect.height() as i32 - h as i32) / 2;
+
+		core.wincan.set_blend_mode(BlendMode::Blend);
+		core.wincan.set_draw_color(color);
+		core.wincan.fill_rect(self.rect)?;
+		core.wincan.copy(&self.texture, None, Rect::new(self.rect.x() + x, self.rect.y() + y, w, h))?;
+		Ok(())
+	}
+}

--- a/src/credits.rs
+++ b/src/credits.rs
@@ -25,9 +25,6 @@ macro_rules! credits_page {
 pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 	let texture_creator = core.wincan.texture_creator();
 
-	let bold_font = core.ttf_ctx.load_font("fonts/OpenSans-Bold.ttf", 32)?; //From https://www.fontsquirrel.com/fonts/open-sans
-	let regular_font = core.ttf_ctx.load_font("fonts/OpenSans-Regular.ttf", 16)?; //From https://www.fontsquirrel.com/fonts/open-sans
-
 	//Music
 	sdl2::mixer::open_audio(44100, AUDIO_S32SYS, DEFAULT_CHANNELS, 1024)?;
 	let _mixer_filetypes = sdl2::mixer::init(InitFlag::MP3)?;
@@ -40,7 +37,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(63, 191, 191, 128));
 		core.wincan.clear();
 
-		let text_surface = bold_font.render("Castle Quest")
+		let text_surface = core.bold_font.render("Castle Quest")
 			.blended_wrapped(Color::RGBA(0, 0, 0, 96), 100) //Black font
 			.map_err(|e| e.to_string())?;
 
@@ -55,7 +52,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(60, 163, 62, 128));
 		core.wincan.clear();
 
-		let text_surface = regular_font.render("AI Subteam")
+		let text_surface = core.regular_font.render("AI Subteam")
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 160) //Black font
 			.map_err(|e| e.to_string())?;
 
@@ -91,7 +88,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		let jared_credit = texture_creator.load_texture("images/credits/JaredCCreditImage.png")?;
 		core.wincan.copy(&jared_credit, None, centered_rect!(core, _, 200, 256, 200))?;
 
-		let text_surface = regular_font.render("Jared Carl")
+		let text_surface = core.regular_font.render("Jared Carl")
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 320)
 			.map_err(|e| e.to_string())?;
 
@@ -115,7 +112,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		core.wincan.set_draw_color(Color::RGBA(238, 46, 21, 128));
 		core.wincan.clear();
 
-		let text_surface = regular_font.render("Networking Subteam")
+		let text_surface = core.regular_font.render("Networking Subteam")
 			.blended_wrapped(Color::RGBA(0, 0, 0, 128), 320) //Black font
 			.map_err(|e| e.to_string())?;
 
@@ -130,7 +127,7 @@ pub fn credits(core: &mut SDLCore) -> Result<GameState, String> {
 		let james_credit = texture_creator.load_texture("images/credits/JamesFCreditImage.png")?;
 		core.wincan.copy(&james_credit, None, centered_rect!(core, _, 200, 256, 256))?;
 
-		let text_surface = regular_font.render("James Fenn")
+		let text_surface = core.regular_font.render("James Fenn")
 			.blended_wrapped(Color::RGBA(128, 128, 128, 128), 320) //Black font
 			.map_err(|e| e.to_string())?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,17 +6,22 @@ const CAM_H: u32 = 720;
 pub const TILE_SIZE: u32 = 32;
 
 use sdl2::rect::Rect;
-use sdl2::render::Texture;
+use sdl2::render::TextureCreator;
+use std::path::Path;
+use sdl2::mixer::{InitFlag, AUDIO_S32SYS, DEFAULT_CHANNELS};
 
 #[macro_use] mod sdl_macros;
 
 mod credits;
+pub mod button;
 mod main_menu;
 mod pixel_coordinates;
 mod single_player;
 pub mod unit;
 pub mod tile;
 mod unit_interface;
+
+use crate::main_menu::MainMenu;
 
 pub enum GameState {
 	MainMenu,
@@ -32,58 +37,20 @@ pub enum PlayerAction {
 	ChoosingUnitAction,
 }
 
-pub struct SDLCore {
+pub struct SDLCore<'t> {
 	pub sdl_ctx: sdl2::Sdl,
-	pub ttf_ctx: sdl2::ttf::Sdl2TtfContext,
+	pub bold_font: sdl2::ttf::Font<'t, 't>,
+	pub regular_font: sdl2::ttf::Font<'t, 't>,
 	pub wincan: sdl2::render::WindowCanvas,
+	pub texture_creator: &'t TextureCreator<sdl2::video::WindowContext>,
 	pub event_pump: sdl2::EventPump,
 	pub cam: Rect,
 }
 
-fn runner(vsync:bool) {
-	println!("\nRunning {}:", TITLE);
-	print!("\tInitting...");
-	match init_sdl_core(vsync) {
-		Err(e) => println!("\n\t\tFailed to init: {}", e),
-		Ok(mut core) => {
-			println!("DONE");
-			print!("\tRunning...");
+fn runner(vsync:bool) -> Result<(), String> {
+	print!("\tRunning...");
 
-			//Start the game in the menu
-			let mut game_state = GameState::MainMenu;
-
-			loop {
-				match run_game_state(&mut core, &game_state) {
-					Err(e) => {
-						panic!("\n\t\tEncountered error while running: {}", e);
-					},
-					Ok(next_game_state) => {
-						match next_game_state {
-							GameState::Quit => break,
-							_ => { game_state = next_game_state; },
-						}
-					},
-				};
-			}
-
-			println!("DONE\nExiting cleanly");
-		},
-	};
-}
-
-fn run_game_state(core: &mut SDLCore, game_state: &GameState) -> Result<GameState, String> {
-	let next_game_state = match game_state {
-		GameState::MainMenu => main_menu::main_menu(core)?,
-		GameState::SinglePlayer => single_player::single_player(core)?,
-		GameState::Credits => credits::credits(core)?,
-		GameState::Quit => GameState::Quit,
-		_ => return Err("Invalid game state".to_string()),
-	};
-
-	Ok(next_game_state)
-}
-
-fn init_sdl_core(vsync:bool) -> Result<SDLCore, String> {
+	// ----- Initialize SDLCore -----
 	let sdl_ctx = sdl2::init()?;
 	let ttf_ctx = sdl2::ttf::init().map_err(|e| e.to_string())?;
 	let video_subsys = sdl_ctx.video()?;
@@ -109,15 +76,66 @@ fn init_sdl_core(vsync:bool) -> Result<SDLCore, String> {
 
 	let cam = Rect::new(0, 0, CAM_W, CAM_H);
 
-	let core = SDLCore{
+	let texture_creator = wincan.texture_creator();
+
+	let bold_font = ttf_ctx.load_font("fonts/OpenSans-Bold.ttf", 32)?; //From https://www.fontsquirrel.com/fonts/open-sans
+	let regular_font = ttf_ctx.load_font("fonts/OpenSans-Regular.ttf", 16)?; //From https://www.fontsquirrel.com/fonts/open-sans
+
+	let mut core = SDLCore{
 		sdl_ctx,
-		ttf_ctx,
+		bold_font,
+		regular_font,
 		wincan,
+		texture_creator: &texture_creator,
 		event_pump,
 		cam,
 	};
 
-	Ok(core)
+	// ----- Start the game loop in the menu -----
+	let mut game_state = GameState::MainMenu;
+
+	loop {
+		game_state = match game_state {
+			GameState::Quit => break,
+			_ => run_game_state(&mut core, &game_state)?,
+		}
+	}
+
+	println!("DONE\nExiting cleanly");
+	Ok(())
+}
+
+fn run_game_state<'i, 'r>(core: &'i mut SDLCore<'r>, game_state: &GameState) -> Result<GameState, String> {
+	let state = match game_state {
+		// This is a specific loop implementation for the MainMenu struct, as it is the only scene with this structure
+		// - this function could be abstracted as the other files are refactored; ideally, `GameState` is a Option<Fn(SDLCore) -> Scene>, where Scene is a trait impemented for every scene struct
+		// - this way, `main_menu` can choose to `return Ok(SinglePlayer::init);`, which this function will use to initialize the singleplayer scene and move its iteration to that function's return value
+		GameState::MainMenu => {
+			let mut scene_menu = MainMenu::new(core)?;
+
+			// background music for main menu
+			// - This had to be moved into a scope that exists outside of both the `main_menu.rs` functions as it needs a persistent lifetime (otherwise it segfaults)
+			// - in the future, this should be abstracted; we could create a `sound_queue: Vec<Path>` in SDLCore that any function can push to in order to play sounds
+			sdl2::mixer::open_audio(44100, AUDIO_S32SYS, DEFAULT_CHANNELS, 1024)?;
+			let _mixer_filetypes = sdl2::mixer::init(InitFlag::MP3)?;
+			let bg_music = sdl2::mixer::Music::from_file(Path::new("./music/main_menu.mp3"))?;
+
+			bg_music.play(-1)?;
+
+			loop {
+				let state = scene_menu.draw()?;
+				match state {
+					GameState::MainMenu => continue,
+					_ => return Ok(state),
+				}
+			}
+		},
+		GameState::SinglePlayer => single_player::single_player(core)?,
+		GameState::Credits => credits::credits(core)?,
+		_ => return Err("Exit game state".to_string())
+	};
+
+	Ok(state)
 }
 
 fn main() {

--- a/src/main_menu.rs
+++ b/src/main_menu.rs
@@ -2,201 +2,178 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::mouse::MouseState;
 use sdl2::image::LoadTexture;
+use sdl2::render::Texture;
 use std::time::Instant;
 
 use crate::GameState;
 use crate::SDLCore;
+use crate::button::Button;
 
-use std::path::Path;
-use sdl2::mixer::{InitFlag, AUDIO_S32SYS, DEFAULT_CHANNELS};
+pub struct MainMenu<'i, 'r> {
+	core: &'i mut SDLCore<'r>,
 
-pub fn main_menu(core: &mut SDLCore) -> Result<GameState, String> {
-    let texture_creator = core.wincan.texture_creator();
+	bg_frame: usize,
+	bg_textures: Vec<Texture<'i>>,
+	bg_interface: Texture<'i>,
 
-	let bold_font = core.ttf_ctx.load_font("fonts/OpenSans-Bold.ttf", 32)?; //From https://www.fontsquirrel.com/fonts/open-sans
-	let regular_font = core.ttf_ctx.load_font("fonts/OpenSans-Regular.ttf", 16)?; //From https://www.fontsquirrel.com/fonts/open-sans
+	// main menu buttons
+	singleplayer_button: Button<'i>,
+	multiplayer_button: Button<'i>,
+	credits_button: Button<'i>,
 
-	//Single player button
-	let single_player_button = Rect::new(40, 600, 380, 100);
-	let text_surface = bold_font.render("Single Player")
-		.blended_wrapped(Color::RGBA(255, 255, 255, 128), 320) //White font
-		.map_err(|e| e.to_string())?;
+	// multiplayer sub-menu buttons
+	is_multiplayer_open: bool,
+	multiplayer_rect: Rect,
+	multiplayer_create_button: Button<'i>,
+	multiplayer_join_button: Button<'i>,
 
-	let text_texture = texture_creator.create_texture_from_surface(&text_surface)
-		.map_err(|e| e.to_string())?;
+	// join code
+	join_code_rect: Rect,
+	join_code: String,
+	join_code_selected: bool,
+	join_code_selected_time: Instant,
+}
 
-	//Multiplayer button
-	let multiplayer_button = Rect::new(450, 600, 380, 100);
-	let text_surface_multi = bold_font.render("Multiplayer")
-		.blended_wrapped(Color::RGBA(255, 255, 255, 128), 320) //White font
-		.map_err(|e| e.to_string())?;
+impl MainMenu<'_, '_> {
 
-	let text_texture_multi = texture_creator.create_texture_from_surface(&text_surface_multi)
-		.map_err(|e| e.to_string())?;
+	pub fn new<'i, 'r>(core: &'i mut SDLCore<'r>) -> Result<MainMenu<'i, 'r>, String> {
+		// bg animation textures
+		let bg_textures: Vec<Texture> = (1..25).map(|i| {
+			core.texture_creator.load_texture(format!("images/main_menu_animation/{}.png", i)).unwrap()
+		}).collect();
+		let bg_interface = core.texture_creator.load_texture("images/interface/unit_interface.png")?;
 
-	//Credit button
-	let credit_button = Rect::new(860, 600, 380, 100);
-	let text_surface2 = bold_font.render("Credits")
-		.blended_wrapped(Color::RGBA(255, 255, 255, 128), 320) //White font
-		.map_err(|e| e.to_string())?;
+		// main menu buttons
+		let singleplayer_button = Button::new(core, Rect::new(40, 600, 380, 100), "Single Player")?;
+		let multiplayer_button = Button::new(core, Rect::new(450, 600, 380, 100), "Multiplayer")?;
+		let credits_button = Button::new(core, Rect::new(860, 600, 380, 100), "Credits")?;
 
-	let text_texture2 = texture_creator.create_texture_from_surface(&text_surface2)
-		.map_err(|e| e.to_string())?;
+		// multiplayer sub-menu buttons
+		let multiplayer_rect = centered_rect!(core, 800, 650);
+		let multiplayer_create_button = Button::new(core, centered_rect!(core, _, 90, 400, 100), "Create Room")?;
+		let multiplayer_join_button = Button::new(core, centered_rect!(core, _, 520, 400, 100), "Join Room")?;
+
+		let join_code_rect = centered_rect!(core, _, 400, 400, 60);
+
+		Ok(MainMenu {
+			core,
+			bg_frame: 0,
+			bg_textures,
+			bg_interface,
+
+			singleplayer_button,
+			multiplayer_button,
+			credits_button,
+
+			is_multiplayer_open: false,
+			multiplayer_rect,
+			multiplayer_create_button,
+			multiplayer_join_button,
+
+			join_code_rect,
+			join_code: String::from(""),
+			join_code_selected: false,
+			join_code_selected_time: Instant::now(),
+		})
+	}
 
 
-	// Multiplayer menu
-	let mut multiplayer_selected = false;
-
-	let multiplayer_create_rect = centered_rect!(core, _, 200, 400, 100);
-	let multiplayer_create_text = texture_creator.create_texture_from_surface(
-		&bold_font.render("Create Room")
-			.blended_wrapped(Color::RGBA(255, 255, 255, 128), 320)
-			.map_err(|e| e.to_string())?
-	).map_err(|e| e.to_string())?;
-
-	let multiplayer_join_rect = centered_rect!(core, _, 480, 400, 80);
-	let multiplayer_join_text = texture_creator.create_texture_from_surface(
-		&bold_font.render("Join Room")
-			.blended_wrapped(Color::RGBA(255, 255, 255, 128), 320)
-			.map_err(|e| e.to_string())?
-	).map_err(|e| e.to_string())?;
-
-	//Join code textbox
-	let join_code_textbox = centered_rect!(core, _, 400, 400, 60);
-	let mut join_code = String::from("");
-	let mut textbox_selected = false;
-	let mut textbox_select_time = Instant::now();
-
-	sdl2::mixer::open_audio(44100, AUDIO_S32SYS, DEFAULT_CHANNELS, 1024)?;
-	let _mixer_filetypes = sdl2::mixer::init(InitFlag::MP3)?;
-	let music = sdl2::mixer::Music::from_file(Path::new("./music/main_menu.mp3"))?;
-
-	music.play(-1);
-
-	//For animation
-	let mut i = 0;
-
-	'menuloop: loop {
-		let mouse_state: MouseState = core.event_pump.mouse_state();
+	pub fn draw(&mut self) -> Result<GameState, String> {
+		let mouse_state: MouseState = self.core.event_pump.mouse_state();
 		let mouse_pos = (mouse_state.x(), mouse_state.y());
 
-		if mouse_state.left() && multiplayer_selected {
-			if join_code_textbox.contains_point(mouse_pos) {
-				textbox_selected = true;
-				textbox_select_time = Instant::now();
-			} else if multiplayer_create_rect.contains_point(mouse_pos) {
+		if mouse_state.left() && self.is_multiplayer_open {
+			if self.join_code_rect.contains_point(mouse_pos) {
+				self.join_code_selected = true;
+				self.join_code_selected_time = Instant::now();
+			} else if self.multiplayer_create_button.is_mouse(self.core) {
 				println!("TODO: create multiplayer room");
-				multiplayer_selected = false;
-			} else if multiplayer_join_rect.contains_point(mouse_pos) {
+				self.is_multiplayer_open = false;
+			} else if self.multiplayer_join_button.is_mouse(self.core) {
 				println!("TODO: join multiplayer room");
-				multiplayer_selected = false;
+				self.is_multiplayer_open = false;
 			} else {
-				textbox_selected = false;
-				multiplayer_selected = false;
+				self.join_code_selected = false;
+				self.is_multiplayer_open = false;
 			}
 		}
 
-		if mouse_state.left() && !multiplayer_selected {
-			if single_player_button.contains_point(mouse_pos) {
+		if mouse_state.left() && !self.is_multiplayer_open {
+			if self.singleplayer_button.is_mouse(self.core) {
 				return Ok(GameState::SinglePlayer);
-			} else if multiplayer_button.contains_point(mouse_pos) {
-				multiplayer_selected = true;
-			} else if credit_button.contains_point(mouse_pos) {
+			} else if self.multiplayer_button.is_mouse(self.core) {
+				self.is_multiplayer_open = true;
+			} else if self.credits_button.is_mouse(self.core) {
 				return Ok(GameState::Credits);
 			}
 		}
 
-		for event in core.event_pump.poll_iter() {
+		for event in self.core.event_pump.poll_iter() {
 			match event {
 				sdl2::event::Event::Quit{..} | sdl2::event::Event::KeyDown{keycode: Some(sdl2::keyboard::Keycode::Escape), ..} => {
-					break 'menuloop;
+					return Err("Quit keycode".to_string());
 				},
 				sdl2::event::Event::KeyDown{keycode: Some(sdl2::keyboard::Keycode::Backspace), ..} => {
-					if textbox_selected && join_code.chars().count() > 0 {
-						let mut char_iter = join_code.chars();
+					if self.join_code_selected && self.join_code.chars().count() > 0 {
+						let mut char_iter = self.join_code.chars();
 						char_iter.next_back();
-						join_code = char_iter.as_str().to_string();
+						self.join_code = char_iter.as_str().to_string();
 					}
 				}
 				sdl2::event::Event::KeyDown{keycode: Some(key), ..} => {
 					let parsed_key = key.to_string();
-					if textbox_selected && join_code.chars().count() < 4 && parsed_key.chars().count() == 1 && parsed_key.chars().next().unwrap().is_numeric() {
-						join_code.push_str(&key.to_string());
+					if self.join_code_selected && self.join_code.chars().count() < 4 && parsed_key.chars().count() == 1 && parsed_key.chars().next().unwrap().is_numeric() {
+						self.join_code.push_str(&key.to_string());
 					}
 				},
 				_ => {},
 			}
 		}
-		i +=1;
-		if i < 24 {
-			sleep_poll!(core, 40);
-			let fr = format!("images/main_menu_animation/{}.png", i);
-			let mm_frame = texture_creator.load_texture(fr)?;
-			core.wincan.copy(&mm_frame, None, None)?;
-		} else {
-			let fr = format!("images/main_menu_animation/{}.png", 24);
-			let mm_frame = texture_creator.load_texture(fr)?;
-			core.wincan.copy(&mm_frame, None, None)?;
-		}
-		if i > 800{
-			i = 1;
+
+		// background animation
+		self.bg_frame += 1;
+		if self.bg_frame < self.bg_textures.len() {
+			self.core.wincan.copy(&self.bg_textures[self.bg_frame], None, None)?;
+		} else if let Some(texture) = self.bg_textures.last() {
+			self.core.wincan.copy(&texture, None, None)?;
 		}
 
-		//let fr = format!("images/main_menu_animation/{}.png", i);
+		if self.bg_frame > 800 {
+			self.bg_frame = 0;
+		}
 
-		if !multiplayer_selected {
-			// Draw singleplayer
-			core.wincan.set_draw_color(Color::RGBA(0,100,0,255));
-			core.wincan.fill_rect(single_player_button)?;
-			core.wincan.copy(&text_texture, None, Rect::new(90, 600, 300, 90))?;
-
-			// Draw multiplayer
-			core.wincan.set_draw_color(Color::RGBA(0,100,0,255));
-			core.wincan.fill_rect(multiplayer_button)?;
-			core.wincan.copy(&text_texture_multi, None, Rect::new(500, 600, 300, 90))?;
-
-			// Draw credits
-			core.wincan.set_draw_color(Color::RGBA(0,100,0,255));
-			core.wincan.fill_rect(credit_button)?;
-			core.wincan.copy(&text_texture2, None, Rect::new(890, 600, 300, 90))?;
+		// buttons
+		if !self.is_multiplayer_open {
+			self.singleplayer_button.draw(self.core)?;
+			self.multiplayer_button.draw(self.core)?;
+			self.credits_button.draw(self.core)?;
 		} else {
-			core.wincan.set_draw_color(Color::RGBA(0, 0, 0, 100));
-			core.wincan.fill_rect(centered_rect!(core, 800, 500))?;
+			// multiplayer sub-menu background
+			self.core.wincan.copy(&self.bg_interface, None, self.multiplayer_rect)?;
 
-			// Draw create room box
-			core.wincan.set_draw_color(Color::RGBA(50,50,50,255));
-			core.wincan.fill_rect(multiplayer_create_rect)?;
-			core.wincan.copy(&multiplayer_create_text, None, centered_rect!(core, _, 210, 300, 80))?;
-
-			// Draw join room box
-			core.wincan.set_draw_color(Color::RGBA(50,50,50,255));
-			core.wincan.fill_rect(multiplayer_join_rect)?;
-			core.wincan.copy(&multiplayer_join_text, None, centered_rect!(core, _, 480, 300, 80))?;
+			self.multiplayer_create_button.draw(self.core)?;
+			self.multiplayer_join_button.draw(self.core)?;
 
 			// Draw join code box
-			core.wincan.set_draw_color(Color::RGBA(255,255,255,255));
-			core.wincan.draw_rect(join_code_textbox)?;
+			self.core.wincan.set_draw_color(Color::RGBA(0,0,0,255));
+			self.core.wincan.draw_rect(self.join_code_rect)?;
 
 			//Render text for join code textbox
-			let display_text = format!("{}{}", join_code, if textbox_selected && textbox_select_time.elapsed().subsec_millis()<500 { "|" } else { "" });
-			match regular_font.size_of(&display_text) {
-				Ok((w, h)) => {
-					if w > 0 {
-						let text_surface = regular_font.render(&display_text)
-							.blended(Color::RGBA(255,255,255,255))
-							.map_err(|e| e.to_string())?;
-						let text_texture = texture_creator.create_texture_from_surface(&text_surface)
-							.map_err(|e| e.to_string())?;
-						core.wincan.copy(&text_texture, None, Rect::new(join_code_textbox.x + 20, join_code_textbox.y + (60-h as i32)/2, w, h))?;
-					}
-				},
-				_ => {},
+			let display_text = format!("{}{}", self.join_code, if self.join_code_selected && self.join_code_selected_time.elapsed().subsec_millis()<500 { "|" } else { "" });
+			if let Ok((w, h)) = self.core.regular_font.size_of(&*display_text) {
+				if w > 0 {
+					let text_surface = self.core.regular_font.render(&*display_text)
+						.blended(Color::RGBA(0,0,0,255))
+						.map_err(|e| e.to_string())?;
+					let text_texture = self.core.texture_creator.create_texture_from_surface(&text_surface)
+						.map_err(|e| e.to_string())?;
+					self.core.wincan.copy(&text_texture, None, Rect::new(self.join_code_rect.x + 20, self.join_code_rect.y + (60-h as i32)/2, w, h))?;
+				}
 			}
 		}
 
-		core.wincan.present();
-
+		self.core.wincan.present();
+		Ok(GameState::MainMenu)
 	}
 
-	Ok(GameState::Quit)
 }

--- a/src/single_player.rs
+++ b/src/single_player.rs
@@ -116,9 +116,8 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 
 	let mut text_textures: HashMap<&str, Texture> = HashMap::new();
 	{
-		let bold_font = core.ttf_ctx.load_font("fonts/OpenSans-Bold.ttf", 32)?;
 		text_textures.insert("p1_banner", {
-			let text_surface = bold_font.render("Player 1's Turn")
+			let text_surface = core.bold_font.render("Player 1's Turn")
 					.blended_wrapped(Color::RGBA(0,0,0, current_banner_transparency), 320) //Black font
 					.map_err(|e| e.to_string())?;
 
@@ -127,7 +126,7 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 		});
 
 		text_textures.insert("p2_banner", {
-			let text_surface = bold_font.render("Player 2's Turn")
+			let text_surface = core.bold_font.render("Player 2's Turn")
 					.blended_wrapped(Color::RGBA(0,0,0, current_banner_transparency), 320) //Black font
 					.map_err(|e| e.to_string())?;
 
@@ -136,7 +135,7 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 		});
 
 		text_textures.insert("b_banner", {
-			let text_surface = bold_font.render("Barbarians' Turn")
+			let text_surface = core.bold_font.render("Barbarians' Turn")
 					.blended_wrapped(Color::RGBA(0,0,0, current_banner_transparency), 320) //Black font
 					.map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
This moves the `main_menu.rs` functionality into a `struct MainMenu` with separate `::new` and `::draw` functions. This allows the `SDLCore` reference to be passed around much more easily, and enables a few other abstractions.

- the `Button` struct/impl abstracts the clickable rects previously used in the main menu, and demonstrates passing the `SDLCore` between functions
- the `run_game_state` function in `main.rs` contains a few important changes that will need to be noted when refactoring any other scenes
  * this works (afaik) because `MainMenu::new(core)` is the only mutable reference to `core` in the function scope, and the `SDLCore` can be safely moved back to its original owner once it drops out of scope (when the menu loop exits)
- `ttf_ctx` was causing other problems, so it's been moved out of the `SDLCore` struct
  * however, `bold_font` and `regular_font` have been moved into `SDLCore` in its place, so it is no longer necessary to reinitialize them in every function
- the background music needs a scope that lasts throughout the presence of the main menu in order to play, and will cause a segfault if that is not the case (thanks Rust). I've put it in `run_game_state` for now, with some suggestions to handle any other sound effects in the future