### PR TITLE
Adding Structure Enum to Tile Struct

### DIFF
--- a/src/single_player.rs
+++ b/src/single_player.rs
@@ -24,7 +24,7 @@ use crate::player_state::PlayerState;
 use crate::player_turn;
 use crate::barbarian_turn;
 use crate::SDLCore;
-use crate::tile::Tile;
+use crate::tile::{Tile, Structure};
 use crate::turn_banner::TurnBanner;
 use crate::unit_interface::UnitInterface;
 use crate::unit::{Team, Unit};
@@ -152,9 +152,12 @@ pub fn single_player(core: &mut SDLCore) -> Result<GameState, String> {
 				let letter = &col[..];
 				match letter {
 					//I wanted to do something that wasn't just hardcoding all the textures, but it seems that tile_textures.get() refuses anything that isn't a hard-coded string
-					"║" | "^" | "v" | "<" | "=" | ">" | "t" => game_map.map_tiles.insert((x,y), Tile::new(x, y, false, true, None, tile_textures.get(&letter).unwrap())),
-					"b" | "1" | "2" | " " | "_" => game_map.map_tiles.insert((x,y), Tile::new(x, y, true, true, None, tile_textures.get(&letter).unwrap())),
-					_ => game_map.map_tiles.insert((x,y), Tile::new(x, y, false, false, None, tile_textures.get(&letter).unwrap())),
+					"║" | "^" | "v" | "<" | "=" | ">" | "t" => game_map.map_tiles.insert((x,y), Tile::new(x, y, false, true, None, None, tile_textures.get(&letter).unwrap())),
+					" " => game_map.map_tiles.insert((x,y), Tile::new(x, y, true, true, None, None, tile_textures.get(&letter).unwrap())),
+					"b" | "_" => game_map.map_tiles.insert((x,y), Tile::new(x, y, true, true, None, Some(Structure::Camp), tile_textures.get(&letter).unwrap())),
+					"1" => game_map.map_tiles.insert((x,y), Tile::new(x, y, true, true, None, Some(Structure::PCastle), tile_textures.get(&letter).unwrap())),
+					"2" => game_map.map_tiles.insert((x,y), Tile::new(x, y, true, true, None, Some(Structure::ECastle), tile_textures.get(&letter).unwrap())),
+					  _ => game_map.map_tiles.insert((x,y), Tile::new(x, y, false, false, None, None, tile_textures.get(&letter).unwrap())),
 				};
 				y += 1;
 			}

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -4,15 +4,15 @@ use crate::unit::{Team};
 
 pub enum Structure {
 	Camp,
-	P-Castle,
-	E-Castle,
+	PCastle,
+	ECastle,
 }
 impl PartialEq for Structure {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Structure::Camp, Structure::Camp) => true,
-            (Structure::P-Castle, Structure::P-Castle) => true,
-            (Structure::E-Castle, Structure::E-Castle) => true,
+            (Structure::PCastle, Structure::PCastle) => true,
+            (Structure::ECastle, Structure::ECastle) => true,
             _ => false,
         }
     }
@@ -29,13 +29,14 @@ pub struct Tile<'a> {
 }
 
 impl Tile <'_>{
-    pub fn new<'a> (x:u32, y:u32, is_traversable: bool, can_attack_through: bool, contained_unit_team: Option<Team>, texture: &'a Texture) -> Tile<'a> {
+    pub fn new<'a> (x:u32, y:u32, is_traversable: bool, can_attack_through: bool, contained_unit_team: Option<Team>, contained_structure: Option<Structure>, texture: &'a Texture) -> Tile<'a> {
         Tile {
             x,
             y,
             is_traversable,
             can_attack_through,
             contained_unit_team,
+            contained_structure,
             texture,
         }
     }


### PR DESCRIPTION
- Adding new structure enum
- Adding new variable to Tile: Option(Structure)
- Updated map initialization to include this new variable
- Reason: In order to calculate the value of a tile for enemy AI as well for later determining whether or not a castle is under siege, we need to be able to tell whether the tile contains a structure