### PR TITLE
AI Unit Selection

### DIFF
--- a/src/AI/population_state.rs
+++ b/src/AI/population_state.rs
@@ -158,7 +158,7 @@ impl PopulationState {
             //Don't forget to reinsert the unit into the hashmap
             game_map.enemy_units.insert((newcoord.0, newcoord.1), active_unit);
             if dead_barb {
-                //Need to check and see if this barbarian was converted - currently a 40% chance
+                //Need to check and see if this barbarian was converted - currently a 45% chance
                 let chance = rand::thread_rng().gen_range(0..100);
                 if chance < 45 {
                     print!("Barbarian has been converted.");

--- a/src/player_turn.rs
+++ b/src/player_turn.rs
@@ -181,7 +181,7 @@ pub fn handle_player_turn<'a>(core: &SDLCore<'a>, game_map: &mut GameMap<'a>) ->
                         }
                         active_unit.has_attacked = true;
                         if dead_barb {
-                            //Need to check and see if this barbarian was converted - currently a 40% chance
+                            //Need to check and see if this barbarian was converted - currently a 45% chance
                             let chance = rand::thread_rng().gen_range(0..100);
                             if chance < 45 {
                                 player_state.current_player_action = PlayerAction::ChoosePrimer;


### PR DESCRIPTION
- AI no longer just automatically selects Melee when it converts a barbarian
- Just like the other player, the AI will choose 1 of the 3 base units each with default corresponding stats.
- Updated console output so it is easier to tell which unit type was selected