### PR TITLE
Performance & bug fixes

### DIFF
--- a/src/game_map.rs
+++ b/src/game_map.rs
@@ -525,9 +525,24 @@ pub fn apply_events<'a>(core: &SDLCore<'a>, game_map: &mut GameMap<'a>) -> Resul
 	game_map.event_list_index = new_index;
 
 	// remove any (dead) units that have reached 0 hp
-	game_map.player_units.retain(|_, u| u.hp > 0);
-	game_map.enemy_units.retain(|_, u| u.hp > 0);
-	game_map.barbarian_units.retain(|_, u| u.hp > 0);
+	let mut dead_units: Vec<(u32, u32)> = Vec::new();
+	dead_units.extend(
+		game_map.player_units.values().filter(|u| u.hp == 0).map(|u| (u.x, u.y))
+	);
+	dead_units.extend(
+		game_map.enemy_units.values().filter(|u| u.hp == 0).map(|u| (u.x, u.y))
+	);
+	dead_units.extend(
+		game_map.barbarian_units.values().filter(|u| u.hp == 0).map(|u| (u.x, u.y))
+	);
+
+	for pos in dead_units {
+		game_map.player_units.remove(&pos);
+		game_map.enemy_units.remove(&pos);
+		game_map.barbarian_units.remove(&pos);
+
+		game_map.map_tiles.get_mut(&(pos.1, pos.0)).map(|t| t.update_team(None));
+	}
 
 	Ok(ret)
 }

--- a/src/multi_player.rs
+++ b/src/multi_player.rs
@@ -69,7 +69,6 @@ impl MultiPlayer<'_, '_> {
 		).map_err(|e| e.to_string())?;
 		let room_text_rect = centered_rect!(core, _, 350, room_w, room_h);
 
-		println!("Initializing with is_host:{}", client.is_host);
 		let game_map = GameMap::new(core, if client.is_host { Team::Player } else { Team::Enemy });
 
 		//Set camera size based on map size


### PR DESCRIPTION
- Moves the existing once-per-second polling limitation into a `ClientBuffer` struct
  * Catches networking errors & re-sends missed events on the next frame
  * Limits the entire game to one networking operation per frame (either sending or receiving a single event)
- Resets the map tile teams after a unit has been removed from the map with 0 hp