### PR TITLE
Unit movement animations

### DIFF
--- a/src/banner.rs
+++ b/src/banner.rs
@@ -91,6 +91,7 @@ impl Banner {
 		//After a set amount of seconds pass and if the banner is still visible, start to make the banner disappear
 		if self.initial_banner_output.elapsed() >= Duration::from_millis(BANNER_TIMEOUT) && self.current_banner_transparency != 0 {
 			self.current_banner_transparency -= 25;
+			core.set_animating(true);
 		}
 
 		Ok(())

--- a/src/game_map.rs
+++ b/src/game_map.rs
@@ -193,6 +193,7 @@ impl GameMap<'_> {
 			let max_move = TILE_SIZE as i32;
 			core.cam.x = (core.cam.x - (core.input.mouse_x_old - core.input.mouse_x).clamp(-max_move, max_move)).clamp(-core.cam.w + core.wincan.window().size().0 as i32, 0);
 			core.cam.y = (core.cam.y - (core.input.mouse_y_old - core.input.mouse_y).clamp(-max_move, max_move)).clamp(-core.cam.h + core.wincan.window().size().1 as i32, 0);
+			core.set_animating(true);
 		}
 
 		let (i, j) = PixelCoordinates::matrix_indices_from_pixel(

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,15 +150,16 @@ fn runner(vsync:bool) -> Result<(), String> {
 }
 
 fn run_game_state<'i, 'r>(core: &'i mut SDLCore<'r>, game_state: &GameState) -> Result<GameState, String> {
+	sdl2::mixer::open_audio(44100, AUDIO_S32SYS, DEFAULT_CHANNELS, 1024)?;
+	let _mixer_filetypes = sdl2::mixer::init(InitFlag::MP3)?;
+	let bg_music: sdl2::mixer::Music;
+
 	let mut scene: Box<dyn Drawable> = match game_state {
 		GameState::MainMenu => {
 			// background music for main menu
 			// - This had to be moved into a scope that exists outside of both the `main_menu.rs` functions as it needs a persistent lifetime (otherwise it segfaults)
 			// - in the future, this should be abstracted; we could create a `sound_queue: Vec<Path>` in SDLCore that any function can push to in order to play sounds
-			sdl2::mixer::open_audio(44100, AUDIO_S32SYS, DEFAULT_CHANNELS, 1024)?;
-			let _mixer_filetypes = sdl2::mixer::init(InitFlag::MP3)?;
-			let bg_music = sdl2::mixer::Music::from_file(Path::new("./music/main_menu.mp3"))?;
-
+			bg_music = sdl2::mixer::Music::from_file(Path::new("./music/main_menu.mp3"))?;
 			bg_music.play(-1)?;
 
 			Box::new(MainMenu::new(core)?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,15 @@ pub struct SDLCore<'t> {
 	pub event_pump: sdl2::EventPump,
 	pub cam: Rect,
 	pub input: Input,
+	pub is_animating: bool,
+}
+
+impl SDLCore<'_> {
+
+	pub fn set_animating(&mut self, animating: bool) {
+		self.is_animating = self.is_animating || animating;
+	}
+
 }
 
 fn runner(vsync:bool) -> Result<(), String> {
@@ -123,6 +132,7 @@ fn runner(vsync:bool) -> Result<(), String> {
 		event_pump,
 		cam,
 		input,
+		is_animating: false,
 	};
 
 	// ----- Start the game loop in the menu -----

--- a/src/multi_player.rs
+++ b/src/multi_player.rs
@@ -120,10 +120,14 @@ impl Drawable for MultiPlayer<'_, '_> {
 		}
 
 		// receive a new event from the server
-		match self.client_buffer.poll(&mut self.client) {
-			Ok(Some(event)) => self.game_map.event_list.push(event),
-			Err(e) => println!("Error polling server: {}", e),
-			_ => {},
+		if !self.core.is_animating {
+			match self.client_buffer.poll(&mut self.client) {
+				Ok(Some(event)) => self.game_map.event_list.push(event),
+				Err(e) => println!("Error polling server: {}", e),
+				_ => {},
+			}
+		} else {
+			self.core.is_animating = false;
 		}
 
 		self.core.wincan.clear();

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -114,6 +114,8 @@ impl PartialOrd for QueueObject {
 }
 
 pub struct Unit<'a> {
+    pub draw_x: f64,
+    pub draw_y: f64,
     pub x: u32,
     pub y: u32,
     pub team: Team,
@@ -146,6 +148,8 @@ pub struct Unit<'a> {
 impl Unit <'_>{
     pub fn new<'a> (x:u32, y:u32, team: Team, hp: u32, movement_range: u32, attack_range: u32, accuracy: u32, min_damage:u32, max_damage: u32, texture: &'a Texture, ranged_attacker: bool) -> Unit<'a> {
         Unit {
+            draw_x: -1.0,
+            draw_y: -1.0,
             x,
             y,
             team,
@@ -563,8 +567,17 @@ impl Unit <'_>{
             self.default_sprite_src
         };
 
+        if self.draw_x < 0.0 || self.draw_y < 0.0 {
+            self.draw_x = dest.x as f64;
+            self.draw_y = dest.y as f64;
+        }
+
+        self.draw_x = (self.draw_x + dest.x as f64) / 2.0;
+        self.draw_y = (self.draw_y + dest.y as f64) / 2.0;
+        let rect = Rect::new(self.draw_x as i32, self.draw_y as i32, dest.width(), dest.height());
+
         //Draw the sprite
-        core.wincan.copy(self.texture, src, *dest)?;
+        core.wincan.copy(self.texture, src, rect)?;
 
         Ok(())
     }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -567,13 +567,15 @@ impl Unit <'_>{
             self.default_sprite_src
         };
 
-        if self.draw_x < 0.0 || self.draw_y < 0.0 {
+        let should_animate = dest.intersection(core.cam) != None && (self.draw_x - dest.x as f64).abs() > 0.01 || (self.draw_y - dest.y as f64).abs() > 0.01;
+        if should_animate && self.draw_x > 0.0 && self.draw_y > 0.0 {
+            self.draw_x = (self.draw_x + dest.x as f64) / 2.0;
+            self.draw_y = (self.draw_y + dest.y as f64) / 2.0;
+        } else {
             self.draw_x = dest.x as f64;
             self.draw_y = dest.y as f64;
         }
 
-        self.draw_x = (self.draw_x + dest.x as f64) / 2.0;
-        self.draw_y = (self.draw_y + dest.y as f64) / 2.0;
         let rect = Rect::new(self.draw_x as i32, self.draw_y as i32, dest.width(), dest.height());
 
         //Draw the sprite

--- a/src/unit_interface.rs
+++ b/src/unit_interface.rs
@@ -136,7 +136,7 @@ impl<'a> UnitInterface<'a> {
                 else {
                     core.wincan.copy(texture, Rect::new(0,32,64,16), Rect::new(self.x, self.y+16*(self.txt.len() as i32-1)+(32.0*self.anim_progress) as i32, 64, 16))?;
                 }
-                
+
                 Ok(())
             },
             _ => { Err("Texture not defined.".to_string()) },


### PR DESCRIPTION
- Animates any unit position changes
- Adds an `is_animating` property to `SDLCore` which postpones any network polling during user interaction
- Fixes the background music in the main menu, which had stopped working for some reason