### PR TITLE
Stretch camp bonus

### DIFF
--- a/src/damage_indicator.rs
+++ b/src/damage_indicator.rs
@@ -43,6 +43,24 @@ impl DamageIndicator {
         })
     }
 
+    pub fn new_heal(core: &SDLCore, heal: u32, position: PixelCoordinates) -> Result<DamageIndicator, String> {
+        let text = "+".to_string() + &heal.to_string();
+        let text_size = core.bold_font.size_of(&text).map_err(|_e| "Could not determine text size")?;
+
+        Ok(DamageIndicator {
+            damage: heal,
+            x: position.x.try_into().unwrap(),
+            y: position.y.try_into().unwrap(),
+            is_visible: true,
+
+            last_drawn: Instant::now(),
+            elapsed_time: 0.0,
+
+            text,
+            text_size,
+        })
+    }
+
     pub fn draw<'r>(&mut self, core: &mut SDLCore<'r>) -> Result<(), String> {
         let texture = core.texture_map.get(&self.text).ok_or("Could not obtain a valid damage texture")?;
 
@@ -74,6 +92,19 @@ pub fn load_textures<'r>(textures: &mut HashMap<String, Texture<'r>>, texture_cr
 			texture_creator.create_texture_from_surface(
 				&bold_font.render(&text)
                 	.blended_wrapped(Color::RGBA(255, 0, 0, 255), 320)
+                	.map_err(|e| e.to_string())?
+			).map_err(|e| e.to_string())?
+		);
+	}
+
+    for i in 0..10 {
+		let text = format!("+{}", i);
+		textures.insert(
+			text.to_string(),
+            //Create texture to display the health increase as a string
+			texture_creator.create_texture_from_surface(
+				&bold_font.render(&text)
+                	.blended_wrapped(Color::RGBA(0, 64, 0, 255), 320)
                 	.map_err(|e| e.to_string())?
 			).map_err(|e| e.to_string())?
 		);

--- a/src/game_map.rs
+++ b/src/game_map.rs
@@ -193,6 +193,7 @@ impl GameMap<'_> {
 			let max_move = TILE_SIZE as i32;
 			core.cam.x = (core.cam.x - (core.input.mouse_x_old - core.input.mouse_x).clamp(-max_move, max_move)).clamp(-core.cam.w + core.wincan.window().size().0 as i32, 0);
 			core.cam.y = (core.cam.y - (core.input.mouse_y_old - core.input.mouse_y).clamp(-max_move, max_move)).clamp(-core.cam.h + core.wincan.window().size().1 as i32, 0);
+			core.wincan.set_viewport(core.cam);
 			core.set_animating(true);
 		}
 

--- a/src/game_map.rs
+++ b/src/game_map.rs
@@ -441,8 +441,8 @@ impl GameMap<'_> {
 
 		// deterministically sort hashmap contents by min hp & map position
 		let map_width = self.map_size.0;
-		unit_list.sort_by_key(|u| u.hp);
 		unit_list.sort_by_key(|u| u.x + u.y*map_width as u32);
+		unit_list.sort_by_key(|u| u.hp);
 
 		// apply health increase for each unit
 		for unit in unit_list {
@@ -450,10 +450,12 @@ impl GameMap<'_> {
 			total_heal = total_heal.checked_sub(heal).unwrap_or(0);
 			println!("  Player unit at {:?} healed, {} remaining", (unit.x, unit.y), total_heal);
 
-			self.damage_indicators.push(DamageIndicator::new_heal(core, heal, PixelCoordinates::from_matrix_indices(
-				unit.y.checked_sub(1).unwrap_or(unit.y),
-				unit.x
-			))?);
+			if heal > 0 {
+				self.damage_indicators.push(DamageIndicator::new_heal(core, heal, PixelCoordinates::from_matrix_indices(
+					unit.y.checked_sub(1).unwrap_or(unit.y),
+					unit.x
+				))?);
+			}
 
 			if total_heal == 0 { break; }
 		}

--- a/src/objective_manager.rs
+++ b/src/objective_manager.rs
@@ -7,9 +7,11 @@ const TURNS_TO_CAPTURE: u32 = 3;
 pub struct ObjectiveManager {
     pub p1_castle: (u32, u32),
     pub p1_castle_turns: u32,
+    pub p1_takeovers: (u32, u32),
 
     pub p2_castle: (u32, u32),
     pub p2_castle_turns: u32,
+    pub p2_takeovers: (u32, u32),
 
     pub barbarian_camps: Vec<(u32, u32)>,
     pub taken_over_camps: Vec<((u32, u32), Team)>,
@@ -27,8 +29,10 @@ impl ObjectiveManager {
         ObjectiveManager {
             p1_castle: (0, 0),
             p1_castle_turns: 0,
+            p1_takeovers: (0, 0),
             p2_castle: (0, 0),
             p2_castle_turns: 0,
+            p2_takeovers: (0, 0),
             barbarian_camps: Vec::new(),
             taken_over_camps: Vec::new(),
             barbarian_camps_turns: HashMap::new(),
@@ -48,8 +52,10 @@ impl ObjectiveManager {
         return ObjectiveManager {
             p1_castle: p1_castle_location,
             p1_castle_turns: 0,
+            p1_takeovers: (0, 0),
             p2_castle: p2_castle_location,
             p2_castle_turns: 0,
+            p2_takeovers: (0, 0),
             barbarian_camps: barb_camp_locations,
             taken_over_camps: Vec::new(),
             barbarian_camps_turns,

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -573,6 +573,18 @@ impl Unit <'_>{
 
         Ok(())
     }
+
+    pub fn heal(&mut self, total_heal: u32) -> u32 {
+        println!("Current unit hp: {}/{}", self.hp, self.max_hp);
+        if self.max_hp - self.hp > total_heal {
+            self.hp += total_heal;
+            return 0;
+        } else {
+            let remaining = self.max_hp - self.hp;
+            self.hp = self.max_hp;
+            total_heal - remaining
+        }
+    }
 }
 
 impl fmt::Display for Unit<'_> {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -584,16 +584,13 @@ impl Unit <'_>{
         Ok(())
     }
 
+    // heals the unit & returns the amount of hp applied
     pub fn heal(&mut self, total_heal: u32) -> u32 {
         println!("Current unit hp: {}/{}", self.hp, self.max_hp);
-        if self.max_hp - self.hp > total_heal {
-            self.hp += total_heal;
-            return 0;
-        } else {
-            let remaining = self.max_hp - self.hp;
-            self.hp = self.max_hp;
-            total_heal - remaining
-        }
+        let heal = (self.max_hp - self.hp).min(total_heal);
+        self.hp += heal;
+
+        heal
     }
 }
 


### PR DESCRIPTION
- Each camp taken over adds a specific amount of health to an overall health pool to heal
  - Camp = +1 hp
  - Fortress = +2 hp
- This is then distributed amongst the units until points are used up or all units are healed
- Added to DamageIndicator to show that health has been added to a unit
- Fixed End Turn button's weird movement